### PR TITLE
Title: Refactor `swapBridgeAmount` to `settledAmount` for Enhanced Security in Withdrawal Calculations

### DIFF
--- a/contracts/upgradeable-Bridge/FiberRouter.sol
+++ b/contracts/upgradeable-Bridge/FiberRouter.sol
@@ -26,7 +26,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         address sourceAddress,
         address targetAddress,
         uint256 settledAmount,
-        bytes32 withdrawlData
+        bytes32 withdrawalData
     );
 
     event Withdraw(
@@ -57,7 +57,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         address sourceAddress,
         string targetAddress,
         uint256 settledAmount,
-        bytes32 withdrawlData
+        bytes32 withdrawalData
     );
     event UnoSwapHandled(
         address indexed swapRouter,
@@ -120,7 +120,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         uint256 targetNetwork,
         address targetToken,
         address targetAddress,
-        bytes32 withdrawlData
+        bytes32 withdrawalData
     ) external nonReentrant {
         // Validation checks
         require(token != address(0), "FR: Token address cannot be zero");
@@ -135,7 +135,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         );
         require(amount != 0, "FR: Amount must be greater than zero");
         require(
-            withdrawlData != 0,
+            withdrawalData != 0,
             "FR: withdraw data cannot be empty"
         );
 
@@ -155,7 +155,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             _msgSender(),
             targetAddress,
             amount,
-            withdrawlData
+            withdrawalData
         );
     }
 
@@ -174,7 +174,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         string memory targetNetwork,
         string memory targetToken,
         string memory targetAddress,
-        bytes32 withdrawlData
+        bytes32 withdrawalData
     ) external nonReentrant {
         // Validation checks
         require(token != address(0), "FR: Token address cannot be zero");
@@ -192,7 +192,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             "FR: Target address cannot be empty"
         );
         require(
-            withdrawlData != 0,
+            withdrawalData != 0,
             "FR: withdraw data cannot be empty"
         );
         amount = SafeAmount.safeTransferFrom(token, _msgSender(), pool, amount);
@@ -212,7 +212,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             _msgSender(),
             targetAddress,
             amount,
-            withdrawlData
+            withdrawalData
         );
     }
 
@@ -237,7 +237,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         bytes memory oneInchData,
         address fromToken,
         address foundryToken,
-        bytes32 withdrawlData
+        bytes32 withdrawalData
     ) external nonReentrant {
         // Validation checks
         require(
@@ -259,7 +259,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             "FR: 1inch data cannot be empty"
         );
         require(
-            withdrawlData != 0,
+            withdrawalData != 0,
             "FR: withdraw data cannot be empty"
         );
         amountIn = SafeAmount.safeTransferFrom(
@@ -286,7 +286,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             _msgSender(),
             crossTargetAddress,
             settledAmount,
-            withdrawlData
+            withdrawalData
         );
     }
 
@@ -311,7 +311,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         bytes memory oneInchData,
         address fromToken,
         address foundryToken,
-        bytes32 withdrawlData
+        bytes32 withdrawalData
     ) external nonReentrant {
         // Validation checks
         require(fromToken != address(0), "From token address cannot be zero");
@@ -338,7 +338,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             "Cross target address cannot be empty"
         );
         require(
-            withdrawlData != 0,
+            withdrawalData != 0,
             "FR: withdraw data cannot be empty"
         );
         amountIn = SafeAmount.safeTransferFrom(
@@ -366,7 +366,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             _msgSender(),
             crossTargetAddress,
             settledAmount,
-            withdrawlData
+            withdrawalData
         );
     }
 

--- a/contracts/upgradeable-Bridge/FiberRouter.sol
+++ b/contracts/upgradeable-Bridge/FiberRouter.sol
@@ -25,7 +25,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         uint256 sourceAmount,
         address sourceAddress,
         address targetAddress,
-        uint256 swapBridgeAmount,
+        uint256 settledAmount,
         bytes32 withdrawlData
     );
 
@@ -56,7 +56,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         uint256 sourceAmount,
         address sourceAddress,
         string targetAddress,
-        uint256 swapBridgeAmount,
+        uint256 settledAmount,
         bytes32 withdrawlData
     );
     event UnoSwapHandled(
@@ -120,7 +120,6 @@ contract FiberRouter is Ownable, TokenReceivable {
         uint256 targetNetwork,
         address targetToken,
         address targetAddress,
-        uint256 swapBridgeAmount,
         bytes32 withdrawlData
     ) external nonReentrant {
         // Validation checks
@@ -135,10 +134,6 @@ contract FiberRouter is Ownable, TokenReceivable {
             "FR: Target address cannot be zero"
         );
         require(amount != 0, "FR: Amount must be greater than zero");
-        require(
-            swapBridgeAmount != 0,
-            "FR: Swap bridge amount must be greater than zero"
-        );
         require(
             withdrawlData != 0,
             "FR: withdraw data cannot be empty"
@@ -159,7 +154,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             amount,
             _msgSender(),
             targetAddress,
-            swapBridgeAmount,
+            amount,
             withdrawlData
         );
     }
@@ -179,16 +174,11 @@ contract FiberRouter is Ownable, TokenReceivable {
         string memory targetNetwork,
         string memory targetToken,
         string memory targetAddress,
-        uint256 swapBridgeAmount,
         bytes32 withdrawlData
     ) external nonReentrant {
         // Validation checks
         require(token != address(0), "FR: Token address cannot be zero");
         require(amount != 0, "Amount must be greater than zero");
-        require(
-            swapBridgeAmount != 0,
-            "FR: Swap bridge amount must be greater than zero"
-        );
         require(
             bytes(targetNetwork).length != 0,
             "FR: Target network cannot be empty"
@@ -213,7 +203,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             targetToken,
             targetAddress
         );
-        NonEvmSwap(
+        emit NonEvmSwap(
             token,
             targetToken,
             block.chainid,
@@ -221,12 +211,12 @@ contract FiberRouter is Ownable, TokenReceivable {
             amount,
             _msgSender(),
             targetAddress,
-            swapBridgeAmount,
+            amount,
             withdrawlData
         );
     }
 
-    /*
+    /*s
      @notice Do a local swap and generate a cross-chain swap
      @param swapRouter The local swap router
      @param amountIn The amount in
@@ -244,7 +234,6 @@ contract FiberRouter is Ownable, TokenReceivable {
         uint256 crossTargetNetwork,
         address crossTargetToken,
         address crossTargetAddress,
-        uint256 swapBridgeAmount,
         bytes memory oneInchData,
         address fromToken,
         address foundryToken,
@@ -270,10 +259,6 @@ contract FiberRouter is Ownable, TokenReceivable {
             "FR: 1inch data cannot be empty"
         );
         require(
-            swapBridgeAmount != 0,
-            "FR: Swap bridge amount must be greater than zero"
-        );
-        require(
             withdrawlData != 0,
             "FR: withdraw data cannot be empty"
         );
@@ -283,7 +268,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             address(this),
             amountIn
         );
-        _swapAndCrossOneInch(
+        uint256 settledAmount = _swapAndCrossOneInch(
             amountIn,
             amountOut,
             crossTargetNetwork,
@@ -300,7 +285,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             amountIn,
             _msgSender(),
             crossTargetAddress,
-            swapBridgeAmount,
+            settledAmount,
             withdrawlData
         );
     }
@@ -326,7 +311,6 @@ contract FiberRouter is Ownable, TokenReceivable {
         bytes memory oneInchData,
         address fromToken,
         address foundryToken,
-        uint256 swapBridgeAmount,
         bytes32 withdrawlData
     ) external nonReentrant {
         // Validation checks
@@ -354,10 +338,6 @@ contract FiberRouter is Ownable, TokenReceivable {
             "Cross target address cannot be empty"
         );
         require(
-            swapBridgeAmount != 0,
-            "FR: Swap bridge amount must be greater than zero"
-        );
-        require(
             withdrawlData != 0,
             "FR: withdraw data cannot be empty"
         );
@@ -367,7 +347,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             address(this),
             amountIn
         );
-        _nonEvmSwapAndCrossOneInch(
+        uint256 settledAmount = _nonEvmSwapAndCrossOneInch(
             amountIn,
             amountOut,
             crossTargetNetwork,
@@ -377,7 +357,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             fromToken,
             foundryToken
         );
-        NonEvmSwap(
+        emit NonEvmSwap(
             fromToken,
             crossTargetToken,
             block.chainid,
@@ -385,7 +365,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             amountIn,
             _msgSender(),
             crossTargetAddress,
-            swapBridgeAmount,
+            settledAmount,
             withdrawlData
         );
     }
@@ -647,7 +627,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         bytes memory oneInchData,
         address fromToken,
         address foundryToken
-    ) internal {
+    ) internal returns (uint256 FMAmountOut){
         IERC20(fromToken).safeApprove(oneInchAggregatorRouter, amountIn);
         uint256 oneInchAmountOut = swapHelperForOneInch(
             payable(pool),
@@ -656,7 +636,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             amountOut,
             oneInchData
         );
-        uint256 FMAmountOut = FundManager(pool).swapToAddress(
+        FMAmountOut = FundManager(pool).swapToAddress(
             foundryToken,
             amountOut,
             crossTargetNetwork,
@@ -677,7 +657,7 @@ contract FiberRouter is Ownable, TokenReceivable {
         bytes memory oneInchData,
         address fromToken,
         address foundryToken
-    ) internal {
+    ) internal returns (uint256 FMAmountOut){
         IERC20(fromToken).safeApprove(oneInchAggregatorRouter, amountIn);
         uint256 oneInchAmountOut = swapHelperForOneInch(
             payable(pool),
@@ -686,7 +666,7 @@ contract FiberRouter is Ownable, TokenReceivable {
             amountOut,
             oneInchData
         );
-        uint256 FMAmountOut = FundManager(pool).nonEvmSwapToAddress(
+        FMAmountOut = FundManager(pool).nonEvmSwapToAddress(
             foundryToken,
             amountOut,
             crossTargetNetwork,

--- a/contracts/upgradeable-Bridge/FiberRouter.sol
+++ b/contracts/upgradeable-Bridge/FiberRouter.sol
@@ -489,9 +489,9 @@ contract FiberRouter is Ownable, TokenReceivable {
         if (receivedSelector == OneInchDecoder.selectorUnoswap) {
             returnAmount = handleUnoSwap(to, srcToken, amountIn, amountOut, oneInchData);
         } else if (receivedSelector == OneInchDecoder.selectorUniswapV3Swap) {
-            handleUniswapV3Swap(to, amountIn, amountOut, oneInchData);
+            returnAmount = handleUniswapV3Swap(to, amountIn, amountOut, oneInchData);
         } else if (receivedSelector == OneInchDecoder.selectorSwap) {
-            handleSwap(to, srcToken, amountIn, amountOut, oneInchData);
+            returnAmount = handleSwap(to, srcToken, amountIn, amountOut, oneInchData);
         } else {
             revert("FR: incorrect oneInchData");
         }

--- a/contracts/upgradeable-Bridge/FundManager.sol
+++ b/contracts/upgradeable-Bridge/FundManager.sol
@@ -301,7 +301,7 @@ contract FundManager is SigCheckable, WithAdmin, TokenReceivable {
         return (digest, _signer);
     }
 
-    function addLiquidity(address token, uint256 amount) external nonReentrant {
+    function addLiquidity(address token, uint256 amount) external {
         require(amount != 0, "Amount must be positive");
         require(token != address(0), "Bad token");
         require(

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@cosmjs/proto-signing": "^0.29.2",
     "@cosmjs/stargate": "^0.29.2",
     "@nomiclabs/hardhat-web3": "^2.0.0",
-    "@openzeppelin/contracts": "^4.8.3",
+    "@openzeppelin/contracts": "^4.0.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.0-rc.1",
     "@openzeppelin/hardhat-upgrades": "^1.21.0",
     "axios": "^1.1.3",

--- a/scripts/deploy/deployFundManager.js
+++ b/scripts/deploy/deployFundManager.js
@@ -1,15 +1,12 @@
 const { ethers, upgrades } = require("hardhat");
 
 async function main() {
-  const FundManager = await ethers.getContractFactory("FundManager");
-  console.log("Deploying FundManager...");
+  const FiberRouter = await hre.ethers.getContractFactory("FiberRouter");
+  const fiberRouter = await FiberRouter.deploy();
 
-  const fundManager = await upgrades.deployProxy(FundManager, {
-    initializer: "initialize",
-  });
-  await fundManager.deployed();
+  await fiberRouter.deployed();
 
-  console.log(`FundManager deployed to ${fundManager.address}`);
+  console.log("FiberRouter deployed to:", fiberRouter.address);
 
   if (network.name == "hardhat") return;
   await fundManager.deployTransaction.wait(6);

--- a/scripts/deploy/deployRouter.js
+++ b/scripts/deploy/deployRouter.js
@@ -1,15 +1,12 @@
 const { ethers, upgrades } = require("hardhat");
 
 async function main() {
-  const FiberRouter = await ethers.getContractFactory("FiberRouter");
-  console.log("Deploying Router...");
+  const FiberRouter = await hre.ethers.getContractFactory("FiberRouter");
+  const fiberRouter = await FiberRouter.deploy();
 
-  const fiberRouter = await upgrades.deployProxy(FiberRouter, {
-    initializer: "initialize",
-  });
   await fiberRouter.deployed();
 
-  console.log(`Router deployed to ${fiberRouter.address}`);
+  console.log("FiberRouter deployed to:", fiberRouter.address);
 
   if (network.name == "hardhat") return;
   await fiberRouter.deployTransaction.wait(21);


### PR DESCRIPTION
**Description**:
### Summary
This PR introduces a key update in our contract's handling of fund transfers. We have renamed `swapBridgeAmount` to `settledAmount`, and altered its functionality to enhance security and accuracy in the withdrawal process.

### Changes
- Renamed `swapBridgeAmount` to `settledAmount`.
- Modified the calculation of `settledAmount` to represent the actual amount the Fund Manager (FM) will receive.
- The `settledAmount` now denotes the `amountIn` on the target side,

### Rationale
Previously, `swapBridgeAmount` was calculated before initiating a swap, representing an estimated `amountIn` to be received on the target side. However, this pre-swap estimation posed potential risks, as the actual received amount could differ during the swap. To address this, we've shifted to calculating `settledAmount` internally within the contract after the swap is completed. This approach ensures that `settledAmount` accurately reflects the amount received by the FM, thereby improving the security and accuracy of the subsequent withdrawal calculations.

### Impact
- **Security**: This change mitigates the risk of discrepancies between the estimated and actual received amounts during swaps.
- **Accuracy**: Withdrawal amounts will now be calculated based on the accurate `settledAmount`, leading to more precise and reliable transactions.
